### PR TITLE
Switch to native ES6

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ let objects = await container.list()
 let object = container.Object(objects[0].name)
 // download file
 let dst = fs.createWriteStream("a.txt")
-object.write(dst)
+(await object.get(dst)).body.pipe(dst);
 ```
 
 ## Documentation
@@ -62,7 +62,7 @@ let client = new Swift({
 |tenantId|$OS_TENANT_ID|
 |tenantDomain|$OS_PROJECT_DOMAIN_NAME|
 |tenantDomainId|$OS_PROJECT_DOMAIN_ID|
-|region|$OS_REGION_NAME (v2)|
+|region|$OS_REGION_NAME (v2, v3)|
 |trustId|$OS_TRUST_ID (v3)|
 |endpointType|$OS_ENDPOINT_TYPE|
 

--- a/auth/base.js
+++ b/auth/base.js
@@ -1,5 +1,5 @@
 // abstract class
-module.exports = class AuthBase {
+export default class AuthBase {
   constructor(data) {
     this.data = data
   }
@@ -12,11 +12,11 @@ module.exports = class AuthBase {
     this.unimplemented("authOptions")
   }
 
-  token(response) {
+  token(response, headers) {
     this.unimplemented("token")
   }
 
-  storageUrl(response) {
+  storageUrl(response, headers) {
     this.unimplemented("storageUrl")
   }
 }

--- a/auth/index.js
+++ b/auth/index.js
@@ -1,10 +1,12 @@
-module.exports = function(data) {
-  let version = "v1"
+import Auth1 from './v1.js'
+import Auth2 from './v2.js'
+import Auth3 from './v3.js'
+
+export default function(data) {
   if (data.authUrl.indexOf("v3") != -1) {
-    version = "v3"
+    return new Auth3(data);
   } else if (data.authUrl.indexOf("v2") != -1) {
-    version = "v2"
+    return new Auth2(data);
   }
-  const Auth = require("./"+version)
-  return new Auth(data)
+  return new Auth1(data);
 }

--- a/auth/v1.js
+++ b/auth/v1.js
@@ -1,6 +1,6 @@
-const AuthBase = require("./base")
+import AuthBase from './base.js';
 
-module.exports = class V1Auth extends AuthBase {
+export default class V1Auth extends AuthBase {
   authOptions(authUrl) {
     return {
       url: authUrl,
@@ -12,11 +12,11 @@ module.exports = class V1Auth extends AuthBase {
     }
   }
 
-  token(response) {
-    return response.headers['x-auth-token']
+  token(response, headers) {
+    return headers.get('x-auth-token');
   }
 
-  storageUrl(response) {
-    return response.headers['x-storage-url']
+  storageUrl(response, headers) {
+    return headers.get('x-storage-url');
   }
 }

--- a/auth/v2.js
+++ b/auth/v2.js
@@ -1,6 +1,6 @@
-const AuthBase = require("./base")
+import AuthBase from './base.js';
 
-module.exports = class V2Auth extends AuthBase {
+export default class V2Auth extends AuthBase {
   json() {
     let v2Auth = {}
     v2Auth.region = this.data.region
@@ -30,19 +30,20 @@ module.exports = class V2Auth extends AuthBase {
     return {
       url: authUrl + "/tokens",
       method: 'POST',
-      json: this.json()
+      headers: {'Content-Type': 'application/json'},
+      body: JSON.stringify(this.json())
     }
   }
 
-  token(response) {
-    return response.body.access.token.id
+  token(response, headers) {
+    return response.access.token.id;
   }
 
-  storageUrl(response) {
+  storageUrl(response, headers) {
     let type = "object-store"
     let region = this.data.region || ""
 
-    let catalog = response.body.access.serviceCatalog.find(e => e.type == type)
+    let catalog = response.access.serviceCatalog.find(e => e.type == type)
     if (!catalog) {
       throw new Error("catalog not found")
     }

--- a/container.js
+++ b/container.js
@@ -1,6 +1,6 @@
-const SwiftObject = require("./object")
+import SwiftObject from './object.js';
 
-module.exports = class SwiftContainer {
+export default class SwiftContainer {
   constructor(client, name) {
     this.client = client
     this.name = name
@@ -18,19 +18,12 @@ module.exports = class SwiftContainer {
   * Show container details and list objects
   */
   async list() {
-    return this.client.call({
-      url: this.url(),
+    let response = await this.client.call({
+      url: this.url() + '?format=json',
       method: "GET",
-      qs: {
-        format: "json"
-      }
-    }, (resolve, response) => {
-      if (response.body) {
-        resolve(JSON.parse(response.body))
-      } else {
-        resolve([])
-      }
-    })
+    });
+
+    return response.body ? await response.json() : [];
   }
 
   /**
@@ -41,12 +34,10 @@ module.exports = class SwiftContainer {
   * Show container metadata
   */
   async metadata() {
-    return this.client.call({
+    return (await this.client.call({
       url: this.url(),
       method: "HEAD"
-    }, (resolve, response) => {
-      resolve(response.headers)
-    })
+    })).headers;
   }
 
   /**
@@ -57,13 +48,11 @@ module.exports = class SwiftContainer {
   * Create, update, or delete container metadata
   */
   async updateMetadata(headers) {
-    return this.client.call({
+    return (await this.client.call({
       url: this.url(),
       method: "POST",
       headers: headers
-    }, (resolve, response) => {
-      resolve(response.headers)
-    })
+    })).headers;
   }
 
   Object(name) {
@@ -78,13 +67,11 @@ module.exports = class SwiftContainer {
   * Create or replace object
   */
   async create(objectName, readStream) {
-    return this.client.call({
+    return this.Object(await this.client.call({
       url: this.url()+"/"+objectName,
       method: "PUT",
       body: readStream
-    }, (resolve, response) => {
-      resolve(this.Object(objectName))
-    })
+    }));
   }
 
   /**
@@ -95,11 +82,9 @@ module.exports = class SwiftContainer {
   * Delete object
   */
   async delete(objectName) {
-    return this.client.call({
+    return (await this.client.call({
       url: this.url()+"/"+objectName,
       method: "DELETE"
-    }, (resolve, response) => {
-      resolve(response.headers)
-    })
+    })).headers;
   }
 }

--- a/object.js
+++ b/object.js
@@ -1,4 +1,4 @@
-module.exports = class SwiftObject {
+export default class SwiftObject {
 
   constructor(container, name) {
     this.container = container
@@ -16,11 +16,15 @@ module.exports = class SwiftObject {
   * /v1/{account}/{container}/{object}
   * Get object content and metadata
   */
-  async write(stream) {
-    return this.container.client.callWithPipe({
+  async write() {
+    return this.container.client.call({
       url: this.url(),
-      method: "GET"
-    }, stream)
+      method: "GET",
+    });
+  }
+
+  async get() {
+    return this.write();
   }
 
   /**
@@ -36,9 +40,7 @@ module.exports = class SwiftObject {
       url: this.url(),
       method: "COPY",
       headers: headers
-    }, (resolve, response) => {
-      resolve(response)
-    })
+    });
   }
 
   /**
@@ -49,12 +51,10 @@ module.exports = class SwiftObject {
   * Show object metadata
   */
   async metadata() {
-    return this.container.client.call({
+    return (await this.container.client.call({
       url: this.url(),
       method: "HEAD"
-    }, (resolve, response) => {
-      resolve(response.headers)
-    })
+    })).headers;
   }
 
   /**
@@ -65,12 +65,10 @@ module.exports = class SwiftObject {
   * Create or update object metadata
   */
   async updateMetadata(headers) {
-    return this.container.client.call({
+    return await (this.container.client.call({
       url: this.url(),
       method: "POST",
       headers: headers
-    }, (resolve, response) => {
-      resolve(response.headers)
-    })
+    })).headers;
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
-  "name": "swift",
-  "version": "1.0.0",
+  "name": "client-swift",
+  "version": "0.1.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -216,6 +216,12 @@
       "requires": {
         "mime-db": "~1.37.0"
       }
+    },
+    "node-fetch": {
+      "version": "2.6.1",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.1.tgz",
+      "integrity": "sha512-V4aYg89jEoVRxRb2fJdAg8FHvI7cEyYdVAh94HH0UIK8oJxUfkjlDQN9RbMx+bEjP7+ggMiFRprSti032Oipxw==",
+      "dev": true
     },
     "oauth-sign": {
       "version": "0.9.0",

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "0.1.1",
   "description": "Object Storage OpenStack Swift client for Node.js",
   "main": "index.js",
+  "type": "module",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1"
   },
@@ -14,7 +15,7 @@
   ],
   "author": "matsune",
   "license": "ISC",
-  "dependencies": {
-    "request": "^2.88.0"
+  "devDependencies": {
+    "node-fetch": "^2.6.1"
   }
 }

--- a/request.js
+++ b/request.js
@@ -1,36 +1,19 @@
-const _request = require("request")
+import fetch from 'node-fetch';
 
-function isOk(response) {
-  return response && 199 < response.statusCode && response.statusCode < 300
-}
+export default async function request(options) {
+  let url = options.url;
 
-function onError(reject, error, response) {
-  if (error) {
-    reject(error)
-  } else if (response.body.error) {
-    reject(response.body.error)
-  } else {
-    reject(response.body)
+  // console.log("Sending", JSON.stringify({...options, ...{body: ""}}));
+  // console.log("Body   ", options.body);
+  try {
+    let response = await fetch(url, options);
+    if (response.ok) {
+      // console.log("Response", response, Object.fromEntries(response.headers.entries()));
+      return response;
+    }
+
+    throw new Error("Request error: " + await response.text());
+  } catch(e) {
+    throw e;
   }
-}
-
-exports.request = function(options, onSuccess) {
-  return new Promise((resolve, reject) => {
-    _request(options, (error, response, body) => {
-      if (isOk(response)) {
-        onSuccess(resolve, response)
-      } else {
-        onError(reject, error, response)
-      }
-    })
-  })
-}
-
-exports.requestWithPipe = function(options, pipe) {
-  return new Promise((resolve, reject) => {
-    _request(options)
-      .on('error', (e) => reject(e))
-      .on('end', resolve)
-      .pipe(pipe)
-  })
 }


### PR DESCRIPTION
- Works in node *AND* (if removing the the 'node-fetch' import) in recent browsers too
- `requests` was deprecated, adapt to `node-fetch` (and the common fetch semantics)
- Adapt to Fetch's Headers / Response objects semantics.
- Use cleaner await to handle async' code.
- Added `object.get()` as a new alias for `object.write()`
- Fix specifying the "region" in keystone v3 (fix #1)
- Codebase decreased by 40 LoC (of ~ 400 LoC)